### PR TITLE
Add v4 notification enum, merge notification v1 into v2

### DIFF
--- a/eve_glue/__init__.py
+++ b/eve_glue/__init__.py
@@ -10,7 +10,6 @@ from eve_glue.location_flag import CorporationLocationFlagEnumV1  # noqa
 from eve_glue.location_flag import CorporationLocationFlagEnumV2  # noqa
 from eve_glue.wallet_journal_ref import JournalRefTypeEnumV2  # noqa
 from eve_glue.wallet_journal_ref import populate_extra_info  # noqa
-from eve_glue.notification_type import NotificationTypeEnum  # noqa
 from eve_glue.notification_type import NotificationTypeEnumV2  # noqa
 from eve_glue.containers import ActionsEnumV1, PasswordTypeEnumV1  # noqa
 from eve_glue.poco import StructureStateEnumV1  # noqa

--- a/eve_glue/notification_type.py
+++ b/eve_glue/notification_type.py
@@ -200,7 +200,7 @@ NotificationTypeEnumV3 = new_from_enum(  # pylint: disable=invalid-name
     }
 )
 
-NotificationTypeEnumV4 = new_from_enum(  # pyling: disable=invalid-name
+NotificationTypeEnumV4 = new_from_enum(  # pylint: disable=invalid-name
     "NotificationTypeEnumV4",
     NotificationTypeEnumV3,
     add={

--- a/eve_glue/notification_type.py
+++ b/eve_glue/notification_type.py
@@ -6,7 +6,7 @@ import enum
 from eve_glue.enums import new_from_enum
 
 
-class NotificationTypeEnum(enum.Enum):
+class NotificationTypeEnumV2(enum.Enum):
     """Maps notification type IDs to names."""
 
     OldLscMessages = 1
@@ -169,6 +169,7 @@ class NotificationTypeEnum(enum.Enum):
     StructureLostShields = 186
     StructureLostArmor = 187
     StructureDestroyed = 188
+    StructureItemsMovedToSafety = 190
     StructureServicesOffline = 198
     StructureItemsDelivered = 199
     SeasonalChallengeCompleted = 200
@@ -180,25 +181,14 @@ class NotificationTypeEnum(enum.Enum):
     GameTimeAdded = 1032
     NPCStandingsLost = 3001
     NPCStandingsGained = 3002
-    notificationTypeMoonminingExtractionStarted = 202  # noqa pylint: disable=invalid-name
+    MoonminingExtractionStarted = 202
     MoonminingExtractionCancelled = 203
     MoonminingExtractionFinished = 204
     MoonminingLaserFired = 205
     MoonminingAutomaticFracture = 206
-
-
-NotificationTypeEnumV2 = new_from_enum(  # pylint: disable=invalid-name
-    "NotificationTypeEnumV2",
-    NotificationTypeEnum,
-    remove=["notificationTypeMoonminingExtractionStarted"],
-    add={
-        "MoonminingExtractionStarted": 202,
-        "StructureWentLowPower": 207,
-        "StructureWentHighPower": 208,
-        "StructuresReinforcementChanged": 209,
-        "StructureItemsMovedToSafety": 190,
-    },
-)
+    StructureWentLowPower = 207
+    StructureWentHighPower = 208
+    StructuresReinforcementChanged = 209
 
 
 NotificationTypeEnumV3 = new_from_enum(  # pylint: disable=invalid-name
@@ -207,5 +197,14 @@ NotificationTypeEnumV3 = new_from_enum(  # pylint: disable=invalid-name
     add={
         "StructuresJobsPaused": 210,
         "StructuresJobsCancelled": 211,
+    }
+)
+
+NotificationTypeEnumV4 = new_from_enum(  # pyling: disable=invalid-name
+    "NotificationTypeEnumV4",
+    NotificationTypeEnumV3,
+    add={
+        "CombatOperationFinished": 1013,
+        "IndustryOperationFinished": 1014
     }
 )


### PR DESCRIPTION
NotificationTypeEnum is not used by any ESI routes anymore, hence merging
NotificationTypeEnum with NotificationTypeEnumV2.