### PR TITLE
REM defunct roles from roles enum

### DIFF
--- a/eve_glue/corp_roles.py
+++ b/eve_glue/corp_roles.py
@@ -57,8 +57,6 @@ class CorpRolesEnum(enum.Enum):
     Starbase_Defense_Operator = 144115188075855872
     Starbase_Fuel_Technician = 288230376151711744
     Fitting_Manager = 576460752303423488
-    Terrestrial_Combat_Officer = 1152921504606846976
-    Terrestrial_Logistics_Officer = 2305843009213693952
 
 
 def calc_roles_from_mask(mask):


### PR DESCRIPTION
- Removes two roles from Dust514 which are not used in EVE from
    roles enum.
- Issue: https://github.com/esi/esi-issues/issues/913