### PR TITLE
ADD missing notification types to enums

### DIFF
--- a/eve_glue/notification_type.py
+++ b/eve_glue/notification_type.py
@@ -250,10 +250,16 @@ NotificationTypeEnumV8 = new_from_enum(  # pylint: disable=invalid-name
     "NotificationTypeEnumV8",
     NotificationTypeEnumV7,
     add={
+        "InvasionSystemStart": 227,
+        "InvasionCompletedMsg": 228,
         "RaffleCreated": 243,
         "RaffleExpired": 244,
         "RaffleFinished": 245,
         "WarEndedHqSecurityDrop": 246,
-        "StructureImpendingAbandonmentAssetsAtRisk": 249
+        "MissionCanceledTriglavian": 247,
+        "AgentRetiredTrigravian": 248,
+        "StructureImpendingAbandonmentAssetsAtRisk": 249,
+        "OfficeLeaseCanceledInsufficientStandings": 250,
+        "ContractRegionChangedToPochven": 251,
     }
 )


### PR DESCRIPTION
- Adds new notification types to `NotificationTypeEnumV8`.
- Also adds previously missing notification types.
- Reminder: according to ESI changes policy change on 01/05/2020
  extending enums is not a breaking change so we can safely do it
  anytime.