### PR TITLE
ADD missing journal ref types

### DIFF
--- a/eve_glue/wallet_journal_ref.py
+++ b/eve_glue/wallet_journal_ref.py
@@ -138,9 +138,21 @@ JournalRefTypeEnumV4 = new_from_enum(  # pylint: disable=invalid-name
     "JournalRefTypeEnumV4",
     JournalRefTypeEnumV3,
     add={
+        "external_trade_freeze": 136,
+        "external_trade_thaw": 137,
+        "external_trade_delivery": 138,
+        "season_challenge_reward": 139,
         "skill_purchase": 141,
         "item_trader_payment": 142,
+        "flux_ticket_sale": 143,  # hypernet ref group
+        "flux_payout": 144,  # hypernet ref group
+        "flux_tax": 145,  # hypernet ref group
+        "flux_ticket_repayment": 146,  # hypernet ref group
+        "redeemed_isk_token": 147,
+        "daily_challenge_reward": 148,
+        "market_provider_tax": 149,
         "ess_escrow_transfer": 155,
+        "milestone_reward_payment": 156,
     }
 )
 


### PR DESCRIPTION
- Names are based on what is displayed in the game.
- No new ref type enum as we don't treat expanding enums as
  a breaking change anymore.
- Solves:
    - https://github.com/esi/esi-issues/issues/1171
    - https://github.com/esi/esi-issues/issues/1178