### PR TITLE
Add Ice Hold location flag

### DIFF
--- a/eve_glue/location_flag.py
+++ b/eve_glue/location_flag.py
@@ -172,6 +172,7 @@ class PersonalLocationFlagEnumV2(enum.Enum):
     BoosterBay = 176
     SubSystemBay = 177
     FrigateEscapeBay = 179
+    SpecializedIceHold = 181
     HangarAll = 1000
 
 


### PR DESCRIPTION
Motivated by https://sentry.io/organizations/ccpgames/issues/1608709631/?project=1528489&query=is%3Aunresolved while investigating a 504 error on this endpoint.

Flag label taken from zinventory.flag table in monolith DB