### PR TITLE
fix: JournalRefTypeEnumV4

### DIFF
--- a/eve_glue/wallet_journal_ref.py
+++ b/eve_glue/wallet_journal_ref.py
@@ -156,14 +156,6 @@ JournalRefTypeEnumV4 = new_from_enum(  # pylint: disable=invalid-name
         "market_provider_tax": 149,
         "ess_escrow_transfer": 155,
         "milestone_reward_payment": 156,
-    },
-)
-
-
-JournalRefTypeEnumV4 = new_from_enum(  # pylint: disable=invalid-name
-    "JournalRefTypeEnumV4",
-    JournalRefTypeEnumV3,
-    add={
         "under_construction": 166,
         "allignment_based_gate_toll": 168,
         "project_payouts": 170,


### PR DESCRIPTION
- It was doubled by accident.
- We're not bumping endpoints versions when adding new enum values anymore so there's no point in habing new enum version when we add things.